### PR TITLE
Track player match counts

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -3,11 +3,16 @@ import { usePlayers } from '../context/PlayersContext'
 import { generateMatches } from '../lib/algorithm'
 
 const MatchesTab: React.FC = () => {
-  const { players } = usePlayers()
+  const { players, incrementMatches } = usePlayers()
   const [teamSize, setTeamSize] = useState(2)
   const [matches, setMatches] = useState(() => generateMatches(players, 2))
 
   const refresh = () => setMatches(generateMatches(players, teamSize))
+  const recordUsage = () => {
+    const ids = matches.flatMap((m) => [...m.teamA, ...m.teamB].map((p) => p.id))
+    incrementMatches(ids)
+    setMatches(generateMatches(players, teamSize))
+  }
 
   return (
     <div className="p-4 space-y-4 max-w-2xl mx-auto">
@@ -39,6 +44,12 @@ const MatchesTab: React.FC = () => {
           </li>
         ))}
       </ol>
+
+      {matches.length > 0 && (
+        <button className="btn btn-secondary" onClick={recordUsage}>
+          Record match usage
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/PlayersTab.tsx
+++ b/src/components/PlayersTab.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { usePlayers } from '../context/PlayersContext'
 
 const PlayersTab: React.FC = () => {
-  const { players, add, remove } = usePlayers()
+  const { players, add, remove, resetMatches } = usePlayers()
   const [name, setName] = useState('')
   const [level, setLevel] = useState(1)
 
@@ -40,7 +40,9 @@ const PlayersTab: React.FC = () => {
         {players.map((p) => (
           <li key={p.id} className="flex justify-between items-center p-2 border rounded">
             <span>
-              {p.name} <span className="badge badge-secondary ml-2">Lv {p.level}</span>
+              {p.name}
+              <span className="badge badge-secondary ml-2">Lv {p.level}</span>
+              <span className="badge ml-2">{p.matches} matches</span>
             </span>
             <button className="btn btn-sm btn-error" onClick={() => remove(p.id)}>
               ✕
@@ -48,6 +50,12 @@ const PlayersTab: React.FC = () => {
           </li>
         ))}
       </ul>
+
+      {players.length > 0 && (
+        <button className="btn btn-warning w-full" onClick={resetMatches}>
+          Reset match counts
+        </button>
+      )}
     </div>
   )
 }

--- a/src/context/PlayersContext.tsx
+++ b/src/context/PlayersContext.tsx
@@ -4,12 +4,15 @@ export interface Player {
   id: string
   name: string
   level: number // 1..N
+  matches: number
 }
 
 type Ctx = {
   players: Player[]
   add: (name: string, level: number) => void
   remove: (id: string) => void
+  incrementMatches: (ids: string[]) => void
+  resetMatches: () => void
 }
 
 const PlayersContext = createContext<Ctx | undefined>(undefined)
@@ -20,17 +23,35 @@ export const PlayersProvider: React.FC<{ children: React.ReactNode }> = ({ child
   // ---- localStorage persistence ------------------------------------------
   useEffect(() => {
     const raw = localStorage.getItem('sbm_players')
-    if (raw) setPlayers(JSON.parse(raw))
+    if (raw) {
+      const parsed: Player[] = JSON.parse(raw)
+      setPlayers(parsed.map((p) => ({ matches: 0, ...p })))
+    }
   }, [])
 
   useEffect(() => {
     localStorage.setItem('sbm_players', JSON.stringify(players))
   }, [players])
 
-  const add = (name: string, level: number) => setPlayers((p) => [...p, { id: crypto.randomUUID(), name, level }])
+  const add = (name: string, level: number) =>
+    setPlayers((p) => [...p, { id: crypto.randomUUID(), name, level, matches: 0 }])
   const remove = (id: string) => setPlayers((p) => p.filter((pl) => pl.id !== id))
+  const incrementMatches = (ids: string[]) =>
+    setPlayers((p) =>
+      p.map((pl) =>
+        ids.includes(pl.id) ? { ...pl, matches: pl.matches + 1 } : pl
+      )
+    )
+  const resetMatches = () =>
+    setPlayers((p) => p.map((pl) => ({ ...pl, matches: 0 })))
 
-  return <PlayersContext.Provider value={{ players, add, remove }}>{children}</PlayersContext.Provider>
+  return (
+    <PlayersContext.Provider
+      value={{ players, add, remove, incrementMatches, resetMatches }}
+    >
+      {children}
+    </PlayersContext.Provider>
+  )
 }
 
 export const usePlayers = () => {

--- a/src/lib/algorithm.ts
+++ b/src/lib/algorithm.ts
@@ -1,6 +1,6 @@
 import type { Player } from '../context/PlayersContext.tsx'
 
-export interface Team extends Array<Player> {}
+export type Team = Player[]
 export interface Match {
   teamA: Team
   teamB: Team
@@ -20,6 +20,11 @@ export function generateMatches(players: Player[], teamSize = 2): Match[] {
   players.forEach((p) => {
     ;(byLevel[p.level] ??= []).push(p)
   })
+
+  // prefer players with fewer matches
+  for (const lvl in byLevel) {
+    byLevel[lvl].sort((a, b) => (a.matches ?? 0) - (b.matches ?? 0))
+  }
 
   // ensure each bucket length is multiple of teamSize
   for (const lvl in byLevel) {


### PR DESCRIPTION
## Summary
- store `matches` count per player in `PlayersContext` and persist in localStorage
- prioritize players with fewer matches in the match generator
- display each player's match count and add a **Reset match counts** button
- add button in Matches tab to record usage of generated matches

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684764742324832184a75a518b162bd2